### PR TITLE
Add npmrc to mute proxy warning

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+; Suppress environment-provided legacy proxy warnings
+loglevel=error

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ npm run dev
 npm run build
 ```
 
+> _Note_: npm is configured with `loglevel=error` (see `.npmrc`) so that
+> environment-provided legacy `http-proxy` settings don't surface warnings
+> during installs or builds. Adjust the log level locally if you need verbose
+> npm output.
+
 ### Production
 ```bash
 # Build optimized assets


### PR DESCRIPTION
## Summary
- add a repo-level `.npmrc` that lowers npm's log level so the environment-provided legacy `http-proxy` setting no longer emits warnings
- document the new npm log-level behavior in the README so developers can opt back into verbose output if desired

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3bd7a10448323bc6ef16e77553520